### PR TITLE
修复 README 中损坏的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,10 @@ TG频道：无
 
 ## Star History
 
-<a href="https://star-history.com/#chengaopan/AutoMergePublicNodes">
+<a href="https://star-history.dera.page/#chengaopan/AutoMergePublicNodes">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=chengaopan/AutoMergePublicNodes&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=chengaopan/AutoMergePublicNodes" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=chengaopan/AutoMergePublicNodes" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=chengaopan/AutoMergePublicNodes&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=chengaopan/AutoMergePublicNodes" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=chengaopan/AutoMergePublicNodes" />
   </picture>
 </a>


### PR DESCRIPTION
README 中的 Star History 图表目前无法正常显示，这影响了项目的展示效果。本 PR 将其切换到可正常工作的服务，确保图表能够重新显示，方便大家查看项目的发展趋势。